### PR TITLE
Modify the pomelo file encoding

### DIFF
--- a/bin/pomelo
+++ b/bin/pomelo
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 /**
- * Module dependencies.
+ * Module dependencies..
  */
 const fs = require('fs'),
   os = require('os'),


### PR DESCRIPTION
解决至少在Centos上无法使用pomelo命令的问题

Modify the pomelo file encoding...
Solve the problem of not being able to use the pomelo command at least on Centos